### PR TITLE
[8.0] add account_invoice_allowed_product module

### DIFF
--- a/account_invoice_allowed_product/README.rst
+++ b/account_invoice_allowed_product/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================================
+Supplier Invoice Allowed Product
+================================
+
+This module adds a restriction in supplier invoices that has the mark "Use only
+allowed products" checked for allowing to select only products that can be
+supplied by the supplier.
+
+The restriction can be set by default for each partner, and it's propagated
+to their supplier invoices, but it can be change for each invoice if you want.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on GitHub Issues. In case of trouble, please check there
+if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+ 
+Credits
+=======
+ 
+Contributors
+------------
+ 
+* Chafique Delli <chafique.delli@akretion.com>
+ 
+Maintainer
+----------
+ 
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its  widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_allowed_product/__init__.py
+++ b/account_invoice_allowed_product/__init__.py
@@ -1,5 +1,2 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
 from . import models

--- a/account_invoice_allowed_product/__init__.py
+++ b/account_invoice_allowed_product/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/account_invoice_allowed_product/__openerp__.py
+++ b/account_invoice_allowed_product/__openerp__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2016 Chafique DELLI @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Account Invoice Allowed Product',
+    'summary': 'This module allows to select only products that can be '
+               'supplied by the supplier',
+    'version': '8.0.1.0.0',
+    'category': 'Accounting & Finance',
+    'website': 'http://akretion.com',
+    'author': 'Akretion, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'installable': True,
+    'depends': [
+        'base',
+        'product',
+        'account',
+    ],
+    'data': [
+        'views/res_partner_view.xml',
+        'views/account_invoice_view.xml'
+    ]
+}

--- a/account_invoice_allowed_product/__openerp__.py
+++ b/account_invoice_allowed_product/__openerp__.py
@@ -8,7 +8,7 @@
                'supplied by the supplier',
     'version': '8.0.1.0.0',
     'category': 'Accounting & Finance',
-    'website': 'http://akretion.com',
+    'website': 'https://akretion.com',
     'author': 'Akretion, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'installable': True,

--- a/account_invoice_allowed_product/i18n/fr.po
+++ b/account_invoice_allowed_product/i18n/fr.po
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_allowed_product
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-10 14:48+0000\n"
+"PO-Revision-Date: 2016-06-10 14:48+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_allowed_product
+#: field:account.invoice,allowed_products:0
+msgid "Allowed products"
+msgstr "Produits autorisés"
+
+#. module: account_invoice_allowed_product
+#: help:res.partner,supplier_invoice_only_allowed:0
+msgid "If checked, by default you will only be able to select products that can be supplied by this supplier when creating a supplier invoice for it. This value can be changed for each invoice."
+msgstr "Si l'option est coché, par défaut, vous pourrez sélectionner que les produits du fournisseur lors de la création d'une facture fournisseur.Cette option est modifiable dans chaque facture. "
+
+#. module: account_invoice_allowed_product
+#: help:account.invoice,only_allowed_products:0
+msgid "If checked, you will only be able to select products that can be supplied by this supplier."
+msgstr "Si l'option est coché, vous pourrez sélectionner que les produits de ce fournisseur ."
+
+#. module: account_invoice_allowed_product
+#: model:ir.model,name:account_invoice_allowed_product.model_account_invoice
+msgid "Invoice"
+msgstr "Facture"
+
+#. module: account_invoice_allowed_product
+#: model:ir.model,name:account_invoice_allowed_product.model_res_partner
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: account_invoice_allowed_product
+#: field:res.partner,supplier_invoice_only_allowed:0
+msgid "Use in supplier invoices only allowed products"
+msgstr "Sélectionner parmis ses produits "
+
+#. module: account_invoice_allowed_product
+#: field:account.invoice,only_allowed_products:0
+msgid "Use only allowed products"
+msgstr "Sélectionner seulement parmis les produits de ce fournisseur"
+
+#. module: account_invoice_allowed_product
+#: view:account.invoice:account_invoice_allowed_product.account_invoice_supplier_form_inh_supplierinvoiceallowedproduct
+#: view:account.invoice.line:account_invoice_allowed_product.invoice_line_form_inh_supplierinvoiceallowedproduct
+msgid "[('id', 'in', parent.allowed_products[0][2])]"
+msgstr "[('id', 'in', parent.allowed_products[0][2])]"
+

--- a/account_invoice_allowed_product/i18n/fr.po
+++ b/account_invoice_allowed_product/i18n/fr.po
@@ -23,12 +23,12 @@ msgstr "Produits autorisés"
 #. module: account_invoice_allowed_product
 #: help:res.partner,supplier_invoice_only_allowed:0
 msgid "If checked, by default you will only be able to select products that can be supplied by this supplier when creating a supplier invoice for it. This value can be changed for each invoice."
-msgstr "Si l'option est coché, par défaut, vous pourrez sélectionner que les produits du fournisseur lors de la création d'une facture fournisseur.Cette option est modifiable dans chaque facture. "
+msgstr "Si l'option est coché, par défaut, vous pourrez sélectionner que les produits de ce fournisseur lors de la création d'une facture avec ce fournisseur.Cette option est modifiable dans chaque facture. "
 
 #. module: account_invoice_allowed_product
 #: help:account.invoice,only_allowed_products:0
 msgid "If checked, you will only be able to select products that can be supplied by this supplier."
-msgstr "Si l'option est coché, vous pourrez sélectionner que les produits de ce fournisseur ."
+msgstr "Si l'option est coché, vous pourrez sélectionner que les produits du fournisseur ci-dessus."
 
 #. module: account_invoice_allowed_product
 #: model:ir.model,name:account_invoice_allowed_product.model_account_invoice
@@ -43,12 +43,12 @@ msgstr "Partenaire"
 #. module: account_invoice_allowed_product
 #: field:res.partner,supplier_invoice_only_allowed:0
 msgid "Use in supplier invoices only allowed products"
-msgstr "Sélectionner parmis ses produits "
+msgstr "Utiliser ses produits "
 
 #. module: account_invoice_allowed_product
 #: field:account.invoice,only_allowed_products:0
 msgid "Use only allowed products"
-msgstr "Sélectionner seulement parmis les produits de ce fournisseur"
+msgstr "Utiliser seulement les produits du fournisseur ci-dessus"
 
 #. module: account_invoice_allowed_product
 #: view:account.invoice:account_invoice_allowed_product.account_invoice_supplier_form_inh_supplierinvoiceallowedproduct

--- a/account_invoice_allowed_product/i18n/fr.po
+++ b/account_invoice_allowed_product/i18n/fr.po
@@ -23,12 +23,12 @@ msgstr "Produits autorisés"
 #. module: account_invoice_allowed_product
 #: help:res.partner,supplier_invoice_only_allowed:0
 msgid "If checked, by default you will only be able to select products that can be supplied by this supplier when creating a supplier invoice for it. This value can be changed for each invoice."
-msgstr "Si l'option est coché, par défaut, vous pourrez sélectionner que les produits de ce fournisseur lors de la création d'une facture avec ce fournisseur.Cette option est modifiable dans chaque facture. "
+msgstr "Si l'option est cochée, par défaut, vous ne pourrez sélectionner que les produits de ce fournisseur lors de la création d'une facture avec ce fournisseur.Cette option est modifiable dans chaque facture. "
 
 #. module: account_invoice_allowed_product
 #: help:account.invoice,only_allowed_products:0
 msgid "If checked, you will only be able to select products that can be supplied by this supplier."
-msgstr "Si l'option est coché, vous pourrez sélectionner que les produits du fournisseur ci-dessus."
+msgstr "Si l'option est cochée, vous ne pourrez sélectionner que les produits du fournisseur ci-dessus."
 
 #. module: account_invoice_allowed_product
 #: model:ir.model,name:account_invoice_allowed_product.model_account_invoice

--- a/account_invoice_allowed_product/models/__init__.py
+++ b/account_invoice_allowed_product/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Chafique DELLI @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import res_partner
+from . import account_invoice

--- a/account_invoice_allowed_product/models/account_invoice.py
+++ b/account_invoice_allowed_product/models/account_invoice.py
@@ -10,8 +10,8 @@ class AccountInvoice(models.Model):
 
     only_allowed_products = fields.Boolean(
         string="Use only allowed products",
-        help="If checked, you will only be able to select products that can be"
-             " supplied by this supplier.")
+        help="If checked, only the products provided by this supplier "
+             "will be shown.")
     allowed_products = fields.Many2many(
         comodel_name='product.product', string='Allowed products')
 
@@ -28,9 +28,10 @@ class AccountInvoice(models.Model):
             partner.commercial_partner_id.supplier_invoice_only_allowed)
         return result
 
-    @api.one
+    @api.multi
     @api.onchange('only_allowed_products')
     def onchange_only_allowed_products(self):
+        self.ensure_one()
         product_obj = self.env['product.product']
         self.allowed_products = product_obj.search(
             [('purchase_ok', '=', True)])

--- a/account_invoice_allowed_product/models/account_invoice.py
+++ b/account_invoice_allowed_product/models/account_invoice.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# © 2016 Chafique DELLI @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    only_allowed_products = fields.Boolean(
+        string="Use only allowed products",
+        help="If checked, you will only be able to select products that can be"
+             " supplied by this supplier.")
+    allowed_products = fields.Many2many(
+        comodel_name='product.product', string='Allowed products')
+
+    @api.multi
+    def onchange_partner_id(self, type, partner_id, date_invoice=False,
+                            payment_term=False, partner_bank_id=False,
+                            company_id=False):
+        result = super(AccountInvoice, self).onchange_partner_id(
+            type=type, partner_id=partner_id, date_invoice=date_invoice,
+            payment_term=payment_term, partner_bank_id=partner_bank_id,
+            company_id=company_id)
+        partner = self.env['res.partner'].browse(partner_id)
+        result['value']['only_allowed_products'] = (
+            partner.commercial_partner_id.supplier_invoice_only_allowed)
+        return result
+
+    @api.one
+    @api.onchange('only_allowed_products')
+    def onchange_only_allowed_products(self):
+        product_obj = self.env['product.product']
+        self.allowed_products = product_obj.search(
+            [('purchase_ok', '=', True)])
+        if self.only_allowed_products and self.partner_id:
+            cond = self._prepare_allowed_product_domain()
+            supplierinfos = self.env['product.supplierinfo'].search(cond)
+            self.allowed_products = product_obj.search(
+                [('product_tmpl_id', 'in',
+                  [x.product_tmpl_id.id for x in supplierinfos])])
+
+    def _prepare_allowed_product_domain(self):
+        return [('name', 'in', (self.partner_id.commercial_partner_id.id,
+                                self.partner_id.id))]

--- a/account_invoice_allowed_product/models/res_partner.py
+++ b/account_invoice_allowed_product/models/res_partner.py
@@ -12,4 +12,4 @@ class ResPartner(models.Model):
         string="Use in supplier invoices only allowed products",
         help="If checked, by default you will only be able to select products"
              " that can be supplied by this supplier when creating a supplier"
-             " invoice for it. This value can be changed for each invoice.")
+             " invoice for it. This value can be set for each invoice.")

--- a/account_invoice_allowed_product/models/res_partner.py
+++ b/account_invoice_allowed_product/models/res_partner.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # © 2016 Chafique DELLI @ Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/account_invoice_allowed_product/models/res_partner.py
+++ b/account_invoice_allowed_product/models/res_partner.py
@@ -1,0 +1,15 @@
+## -*- coding: utf-8 -*-
+# © 2016 Chafique DELLI @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    supplier_invoice_only_allowed = fields.Boolean(
+        string="Use in supplier invoices only allowed products",
+        help="If checked, by default you will only be able to select products"
+             " that can be supplied by this supplier when creating a supplier"
+             " invoice for it. This value can be changed for each invoice.")

--- a/account_invoice_allowed_product/views/account_invoice_view.xml
+++ b/account_invoice_allowed_product/views/account_invoice_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="account_invoice_supplier_form_inh_supplierinvoiceallowedproduct">
+            <field name="name">account.invoice.supplier.form.inh.supplierinvoiceallowedproduct</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form" />
+            <field name="arch" type="xml">
+                <field name="invoice_line" position="before">
+                    <field name="only_allowed_products"
+                           attrs="{'invisible': [('state', 'not in', ('draft', 'send'))]}"
+                           class="oe_edit_only" />
+                    <label for="only_allowed_products"
+                           attrs="{'invisible': [('state', 'not in', ('draft', 'send'))]}"
+                           class="oe_edit_only" />
+                    <field name="allowed_products" invisible="1"/>
+                </field>
+                <xpath expr="//field[@name='invoice_line']/tree/field[@name='product_id']" position="attributes">
+                    <attribute name="domain">[('id', 'in', parent.allowed_products[0][2])]</attribute>
+                </xpath>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="invoice_line_form_inh_supplierinvoiceallowedproduct">
+            <field name="name">account.invoice.line.form.inh.supplierinvoiceallowedproduct</field>
+            <field name="model">account.invoice.line</field>
+            <field name="inherit_id" ref="account.view_invoice_line_form" />
+            <field name="arch" type="xml">
+                <field name="product_id" position="attributes">
+                    <attribute name="domain">[('id', 'in', parent.allowed_products[0][2])]</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/account_invoice_allowed_product/views/res_partner_view.xml
+++ b/account_invoice_allowed_product/views/res_partner_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_partner_form_inh_supplierinvoiceallowedproduct">
+            <field name="name">view.partner.form.inh.supplierinvoiceallowedproduct</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form" />
+            <field name="arch" type="xml">
+                <field name="active" position="after">
+                    <field name="supplier_invoice_only_allowed" attrs="{'invisible': ['|', ('supplier', '=', False), ('parent_id', '!=', False)]}"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This module adds a restriction in supplier invoices that has the mark "Use only
allowed products" checked for allowing to select only products that can be
supplied by the supplier.

The restriction can be set by default for each partner, and it's propagated
to their supplier invoices, but it can be change for each invoice if you want.