### PR TITLE
Fix an issue about tuples and lists

### DIFF
--- a/product_categ_available_pos/__openerp__.py
+++ b/product_categ_available_pos/__openerp__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Product category available in pos by company',
-    'version': '8.0.0.1.0',
+    'version': '8.0.0.1.1',
     'category': 'Point Of Sale',
     'description': """
 Set company_dependent to product.category.available_in_pos.

--- a/product_categ_available_pos/models/available_in_pos_abstract.py
+++ b/product_categ_available_pos/models/available_in_pos_abstract.py
@@ -10,22 +10,28 @@ class AvailabeInPosMixin(models.AbstractModel):
     @api.model
     def search_read(self, domain=None, fields=None, offset=0, limit=None,
                     order=None):
+        # domain may be tuple or list, convert it to list in
+        # order to modify it
+        new_domain = map(list, domain)
         for lvl2 in domain:
             if lvl2[0] == 'available_in_pos':
                 lvl2[0] = 'categ_id.available_in_pos'
 
         res = super(AvailabeInPosMixin, self).search_read(
-            domain=domain, fields=fields, offset=offset,
+            domain=new_domain, fields=fields, offset=offset,
             limit=limit, order=order)
         return res
 
     @api.model
     def search(self, args, offset=0, limit=0, order=None, count=False):
-        for lvl2 in args:
+        # new_args may be tuple or list, convert it to list in
+        # order to modify it
+        new_args = map(list, args)
+        for lvl2 in new_args:
             if lvl2[0] == 'available_in_pos':
                 lvl2[0] = 'categ_id.available_in_pos'
 
         res = super(AvailabeInPosMixin, self).search(
-            args, offset=offset, limit=limit,
+            new_args, offset=offset, limit=limit,
             order=order, count=count)
         return res


### PR DESCRIPTION
Sometimes the domain (or args) is a tuple instead of a list.
So modification is not possible.
This patch always convert a domain into a tuple.