### PR TITLE
[FIX] assign_picking method when stock move is done

### DIFF
--- a/mrp_subcontract_location/models/stock_move.py
+++ b/mrp_subcontract_location/models/stock_move.py
@@ -65,7 +65,7 @@ class StockMove(models.Model):
         # mig v12: remove this function since search_picking_for_assignation
         # is in core
         candidates_for_empty_picking = Picking.browse()
-        for move in self:
+        for move in self.filtered(lambda m: m.state not in ['cancel', 'done']):
             recompute = False
             if move.picking_id:
                 candidates_for_empty_picking += move.picking_id


### PR DESCRIPTION
When trying to confirm an RFQ, we have an Odoo error message.

In fact, in the assign_picking method of stock.move, it tries to delete the pickings even if they are done .

for picking in candidates_for_empty_picking:
if not picking.move_lines:
picking.unlink()