### PR TITLE
14.0 queue job extra

### DIFF
--- a/queue_job_cancel_dead_job/__init__.py
+++ b/queue_job_cancel_dead_job/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/queue_job_cancel_dead_job/__manifest__.py
+++ b/queue_job_cancel_dead_job/__manifest__.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+{
+    "name": "Queue Job Cancel Dead Job",
+    "summary": "Cancel dead pending job",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Uncategorized",
+    "website": "https://github.com/akretion/ak-odoo-incubator",
+    "author": " Akretion",
+    "license": "AGPL-3",
+    "external_dependencies": {
+        "python": [],
+        "bin": [],
+    },
+    "depends": [
+        "queue_job",
+    ],
+    "data": [
+        "data/ir_cron.xml",
+    ],
+    "demo": [],
+}

--- a/queue_job_cancel_dead_job/data/ir_cron.xml
+++ b/queue_job_cancel_dead_job/data/ir_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record forcecreate="True" id="ir_cron_cancel_dead_job" model="ir.cron">
+        <field name="name">Queue Job: cancel dead started job</field>
+        <field name="active" eval="True" />
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">hours</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False" />
+        <field name="model_id" ref="model_queue_job" />
+        <field name="state">code</field>
+        <field name="code">model._cancel_dead_job()</field>
+    </record>
+</odoo>

--- a/queue_job_cancel_dead_job/models/__init__.py
+++ b/queue_job_cancel_dead_job/models/__init__.py
@@ -1,0 +1,1 @@
+from . import queue_job

--- a/queue_job_cancel_dead_job/models/queue_job.py
+++ b/queue_job_cancel_dead_job/models/queue_job.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from datetime import datetime, timedelta
+
+from odoo import models
+from odoo.tools import config
+
+
+class QueueJob(models.Model):
+    _inherit = "queue.job"
+
+    def _cancel_dead_job(self):
+        # search dead job based on worker life duration and cancel them
+        dead_start_date = datetime.now() - timedelta(
+            seconds=config.get("limit_time_real")
+        )
+        jobs = self.search(
+            [("state", "=", "started"), ("date_enqueued", "<", dead_start_date)]
+        )
+        jobs.write({"state": "failed", "result": "dead job"})

--- a/queue_job_default_channel/__init__.py
+++ b/queue_job_default_channel/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/queue_job_default_channel/__manifest__.py
+++ b/queue_job_default_channel/__manifest__.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Queue Job Default Channel",
+    "summary": "Default channel for queue job",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Job",
+    "website": "https://github.com/akretion/ak-odoo-incubator",
+    "author": " Akretion",
+    "license": "AGPL-3",
+    "external_dependencies": {
+        "python": [],
+        "bin": [],
+    },
+    "depends": [
+        "queue_job",
+    ],
+    "data": [
+        "data/queue_job_channel_data.xml",
+    ],
+    "demo": [],
+}

--- a/queue_job_default_channel/data/queue_job_channel_data.xml
+++ b/queue_job_default_channel/data/queue_job_channel_data.xml
@@ -1,0 +1,16 @@
+<odoo noupdate="1">
+    <record model="queue.job.channel" id="channel_default">
+        <field name="name">default</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+
+    <record model="queue.job.channel" id="channel_default_slow_job">
+        <field name="name">slow_job</field>
+        <field name="parent_id" ref="channel_default" />
+    </record>
+
+    <record model="queue.job.channel" id="channel_default_basic_job">
+        <field name="name">basic_job</field>
+        <field name="parent_id" ref="channel_default" />
+    </record>
+</odoo>

--- a/queue_job_default_channel/models/__init__.py
+++ b/queue_job_default_channel/models/__init__.py
@@ -1,0 +1,1 @@
+from . import queue_job_function

--- a/queue_job_default_channel/models/queue_job_function.py
+++ b/queue_job_default_channel/models/queue_job_function.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class QueueJobFunction(models.Model):
+    _inherit = "queue.job.function"
+
+    def job_default_config(self):
+        config = super().job_default_config()
+        return config._replace(channel="root.default.basic_job")

--- a/queue_job_default_channel/tests/__init__.py
+++ b/queue_job_default_channel/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_default_channel

--- a/queue_job_default_channel/tests/test_default_channel.py
+++ b/queue_job_default_channel/tests/test_default_channel.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.tests import SavepointCase
+
+
+class TestDefaultChannel(SavepointCase):
+    def test_default_channel(self):
+        self.env["res.partner"].search([], limit=1).with_delay().write({"name": "Foo"})
+        job = self.env["queue.job"].search(
+            [("func_string", "ilike", "write({'name': 'Foo'})")]
+        )
+        self.assertEqual(job.channel, "root.default.basic_job")

--- a/setup/queue_job_cancel_dead_job/odoo/addons/queue_job_cancel_dead_job
+++ b/setup/queue_job_cancel_dead_job/odoo/addons/queue_job_cancel_dead_job
@@ -1,0 +1,1 @@
+../../../../queue_job_cancel_dead_job

--- a/setup/queue_job_cancel_dead_job/setup.py
+++ b/setup/queue_job_cancel_dead_job/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/queue_job_default_channel/odoo/addons/queue_job_default_channel
+++ b/setup/queue_job_default_channel/odoo/addons/queue_job_default_channel
@@ -1,0 +1,1 @@
+../../../../queue_job_default_channel

--- a/setup/queue_job_default_channel/setup.py
+++ b/setup/queue_job_default_channel/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Add two module for improving queue job
- one for adding default channel and use them by default (in order to never have job in root channel)
- one for canceling dead job (sometime if a job is too long or is block, the worker can be kill and the dead job block the queue)