### PR TITLE
product_pricelist_per_attribute_value: fix case of multi attribute, always use the first most accurate rule

### DIFF
--- a/product_pricelist_per_attribute_value/models/product_pricelist.py
+++ b/product_pricelist_per_attribute_value/models/product_pricelist.py
@@ -23,12 +23,12 @@ class ProductPricelist(models.Model):
 class PricelistItem(models.Model):
     _inherit = "product.pricelist.item"
     _order = (
-        "applied_on, attribute_value_restricted desc, min_quantity desc,"
+        "applied_on, attribute_value_restricted_number desc, min_quantity desc,"
         "categ_id desc, id desc"
     )
 
-    attribute_value_restricted = fields.Boolean(
-        compute="_compute_attribute_value_restricted", store=True
+    attribute_value_restricted_number = fields.Integer(
+        compute="_compute_attribute_value_restricted_number", store=True
     )
     product_attribute_value_ids = fields.Many2many(
         "product.attribute.value",
@@ -44,9 +44,11 @@ class PricelistItem(models.Model):
     )
 
     @api.depends("product_attribute_value_ids")
-    def _compute_attribute_value_restricted(self):
+    def _compute_attribute_value_restricted_number(self):
         for record in self:
-            record.attribute_value_restricted = bool(record.product_attribute_value_ids)
+            record.attribute_value_restricted_number = len(
+                record.product_attribute_value_ids.attribute_id
+            )
 
     @api.depends("applied_on", "product_tmpl_id", "categ_id")
     def _compute_product_attribute_value_domain(self):

--- a/product_pricelist_per_attribute_value/tests/test_pricelist_per_attribute_value.py
+++ b/product_pricelist_per_attribute_value/tests/test_pricelist_per_attribute_value.py
@@ -256,3 +256,51 @@ class TestPriceListPerAttributeValue(SavepointCase):
         )
         self.assertEqual(res1[0], 45.0)
         self.assertEqual(res2[0], 45.0)
+
+    def test_leg_aluminum_global_and_color_white(self):
+        self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "compute_price": "fixed",
+                "fixed_price": 40.0,
+                "applied_on": "1_product",
+                "product_tmpl_id": self.template.id,
+                "product_attribute_value_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.pav_white.id,
+                            self.pav_alu.id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "compute_price": "fixed",
+                "fixed_price": 45.0,
+                "applied_on": "1_product",
+                "product_tmpl_id": self.template.id,
+                "product_attribute_value_ids": [(6, 0, [self.pav_alu.id])],
+            }
+        )
+
+        res1 = self.pricelist.get_product_price_rule(
+            self.variant_alu_white,
+            1,
+            self.partner,
+            date=False,
+            uom_id=self.variant_alu_white.uom_id.id,
+        )
+        res2 = self.pricelist.get_product_price_rule(
+            self.variant_alu_black,
+            1,
+            self.partner,
+            date=False,
+            uom_id=self.variant_alu_black.uom_id.id,
+        )
+        self.assertEqual(res1[0], 40.0)
+        self.assertEqual(res2[0], 45.0)


### PR DESCRIPTION
 fix case of multi attribute, always use the first most accurate rule