### PR TITLE
prj_estim_step: IMP ui removing widget radio

### DIFF
--- a/project_estimate_step/views/project_task_view.xml
+++ b/project_estimate_step/views/project_task_view.xml
@@ -11,7 +11,6 @@
                     name="estimate_step_id"
                     domain="[('id', 'in', allowed_estimate_step_ids)]"
                     attrs="{'invisible': [('allowed_estimate_step_ids', '=', False)]}"
-                    widget="radio"
                 />
             </field>
         </field>


### PR DESCRIPTION
<img width="1250" height="687" alt="image" src="https://github.com/user-attachments/assets/6a24c05d-ff8f-47ee-aa91-3a1b54b7d77c" />


This dirty paging will delayed our global 2026 migrations program around of 1h37min.

We need to fix that.

@Kev-Roche @thibaultrey @sebastienbeau 